### PR TITLE
control sequences inclusion

### DIFF
--- a/getch/getch.py
+++ b/getch/getch.py
@@ -11,7 +11,7 @@ except ImportError:
         fd = sys.stdin.fileno()
         old = termios.tcgetattr(fd)
         try:
-            tty.setcbreak(fd)
+            tty.setraw(fd)
             return sys.stdin.read(1)
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old)

--- a/getch/getch.py
+++ b/getch/getch.py
@@ -11,7 +11,7 @@ except ImportError:
         fd = sys.stdin.fileno()
         old = termios.tcgetattr(fd)
         try:
-            tty.setraw(fd)
+            tty.setcbreak(fd)
             return sys.stdin.read(1)
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old)

--- a/getch/getch.py
+++ b/getch/getch.py
@@ -1,6 +1,11 @@
-try:
-    from msvcrt import getch
-except ImportError:
+import os
+if os.name is 'nt':
+    try:
+        from msvcrt import getch
+    except ImportError:
+        print('Missing package for assumed windows platform: msvcrt')
+        raise
+elif os.name is 'posix':
     def getch():
         """
         Gets a single character from STDIO.

--- a/getch/getch.py
+++ b/getch/getch.py
@@ -14,9 +14,11 @@ elif os.name is 'posix':
         import tty
         import termios
         fd = sys.stdin.fileno()
-        old = termios.tcgetattr(fd)
+        old = termios.tcgetattr(fd) # save termios settings
         try:
+            # set termios settings to turn off echo, newlines, etc..
             tty.setraw(fd)
             return sys.stdin.read(1)
         finally:
+            # restore termios settings
             termios.tcsetattr(fd, termios.TCSADRAIN, old)

--- a/getch/pause.py
+++ b/getch/pause.py
@@ -11,7 +11,8 @@ def pause(message='Press any key to continue . . . '):
     if message is not None:
         print(message, end='')
         sys.stdout.flush()
-    if getch() == '\x03':
+    ch = getch()
+    if ch is '\x03' or ch is b'\x03':
         raise KeyboardInterrupt
     print()
 

--- a/getch/pause.py
+++ b/getch/pause.py
@@ -11,7 +11,8 @@ def pause(message='Press any key to continue . . . '):
     if message is not None:
         print(message, end='')
         sys.stdout.flush()
-    getch()
+    if getch() == '\x03':
+        raise KeyboardInterrupt
     print()
 
 

--- a/getch/pause.py
+++ b/getch/pause.py
@@ -12,6 +12,8 @@ def pause(message='Press any key to continue . . . '):
         print(message, end='')
         sys.stdout.flush()
     ch = getch()
+    # chech for CTRL-C (0x03) code and handle it with an error
+    # check for b'\x03' because windows getch returns a 'bytes' string literal
     if ch is '\x03' or ch is b'\x03':
         raise KeyboardInterrupt
     print()


### PR DESCRIPTION
changed tty.setraw to tty.setcbreak so that control sequences (CTRL-C)
are processed by the console. fixed unescapable loop bug.

example of bug:
>>> from getch import pause
>>> while True: pause()

this loop can't be escaped with CTRL-C if tty.setraw is turned on. with
setcbreak it will exit on CTRL-C.

lets have a good start to 2017!